### PR TITLE
feat: update profile metadata

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -57,6 +57,7 @@ dependencies = [
 name = "allo"
 version = "0.0.1"
 dependencies = [
+ "alexandria_bytes",
  "alexandria_math",
  "openzeppelin",
  "snforge_std",


### PR DESCRIPTION
This PR introduces a new function update_profile_metadata.The function includes a validation step to ensure that only the rightful owner of a profile can update its metadata. Once the metadata is updated an event  ProfileMetadataUpdated is emitted.

Fixes #11
