### PR TITLE
feat/is_member_of_profile & feat/is_owner_or_member_of_profile

### DIFF
--- a/src/core/registry.cairo
+++ b/src/core/registry.cairo
@@ -37,7 +37,7 @@ pub trait IRegistry<TContractState> {
     fn update_profile_metadata(ref self: TContractState, profile_id: u256, metadata: Metadata);
     fn get_profile_by_id(self: @TContractState, profile_id: u256) -> Registry::Profile;
     fn is_member_of_profile(
-        self: @TContractState, profile_id: felt252, member: ContractAddress
+        self: @TContractState, profile_id: u256, member: ContractAddress
     ) -> bool;
 }
 #[starknet::contract]
@@ -212,7 +212,7 @@ pub mod Registry {
         // https://github.com/allo-protocol/allo-v2/blob/4dd0ea34a504a16ac90e80f49a5570b8be9b30e9/contracts/core/Registry.sol#L245
 
         fn is_member_of_profile(
-            self: @ContractState, profile_id: felt252, member: ContractAddress
+            self: @ContractState, profile_id: u256, member: ContractAddress
         ) -> bool {
             return self._is_member_of_profile(profile_id, member);
         }
@@ -306,8 +306,9 @@ pub mod Registry {
         // Down below is the function that is to be implemented in the contract but in cairo.
         // https://github.com/allo-protocol/allo-v2/blob/4dd0ea34a504a16ac90e80f49a5570b8be9b30e9/contracts/core/Registry.sol#L384C14-L384C32
         fn _is_member_of_profile(
-            self: @ContractState, _profile_id: felt252, _owner: ContractAddress
+            self: @ContractState, _profile_id: u256, _owner: ContractAddress
         ) -> bool {
+            let _profile_id: felt252 = _profile_id.try_into().unwrap();
             return self.accessControl.has_role(_profile_id, _owner);
         }
     }

--- a/src/core/registry.cairo
+++ b/src/core/registry.cairo
@@ -36,6 +36,9 @@ pub trait IRegistry<TContractState> {
     fn add_members(ref self: TContractState, profile_Id: u256, members: Array<ContractAddress>);
     fn update_profile_metadata(ref self: TContractState, profile_id: u256, metadata: Metadata);
     fn get_profile_by_id(self: @TContractState, profile_id: u256) -> Registry::Profile;
+    fn is_member_of_profile(
+        self: @TContractState, profile_id: felt252, member: ContractAddress
+    ) -> bool;
 }
 #[starknet::contract]
 pub mod Registry {
@@ -104,7 +107,7 @@ pub mod Registry {
         accessControl: AccessControlComponent::Storage,
         anchor_to_profile_id: LegacyMap<ContractAddress, u256>,
         profile_id_to_pending_owner: LegacyMap<u256, ContractAddress>,
-        member_length: u256
+        member_length: u256,
     }
 
     /// ======================
@@ -208,6 +211,12 @@ pub mod Registry {
         // Down below is the function that is to be implemented in the contract but in cairo.
         // https://github.com/allo-protocol/allo-v2/blob/4dd0ea34a504a16ac90e80f49a5570b8be9b30e9/contracts/core/Registry.sol#L245
 
+        fn is_member_of_profile(
+            self: @ContractState, profile_id: felt252, member: ContractAddress
+        ) -> bool {
+            return self._is_member_of_profile(profile_id, member);
+        }
+
         // Issue no. #9 Implement the functionality of UpdateProfilePendingOwner
         // Down below is the function that is to be implemented in the contract but in cairo.
         // https://github.com/allo-protocol/allo-v2/blob/4dd0ea34a504a16ac90e80f49a5570b8be9b30e9/contracts/core/Registry.sol#L253
@@ -293,9 +302,13 @@ pub mod Registry {
         ) -> bool {
             return self.profiles_by_id.read(_profile_id).owner == _owner;
         }
-    // Issue n. #5 Implement the functionality of _isMemberOfProfile
-    // Down below is the function that is to be implemented in the contract but in cairo.
-    // https://github.com/allo-protocol/allo-v2/blob/4dd0ea34a504a16ac90e80f49a5570b8be9b30e9/contracts/core/Registry.sol#L384C14-L384C32
-
+        // Issue n. #5 Implement the functionality of _isMemberOfProfile
+        // Down below is the function that is to be implemented in the contract but in cairo.
+        // https://github.com/allo-protocol/allo-v2/blob/4dd0ea34a504a16ac90e80f49a5570b8be9b30e9/contracts/core/Registry.sol#L384C14-L384C32
+        fn _is_member_of_profile(
+            self: @ContractState, _profile_id: felt252, _owner: ContractAddress
+        ) -> bool {
+            return self.accessControl.has_role(_profile_id, _owner);
+        }
     }
 }

--- a/src/core/registry.cairo
+++ b/src/core/registry.cairo
@@ -39,6 +39,9 @@ pub trait IRegistry<TContractState> {
     fn is_member_of_profile(
         self: @TContractState, profile_id: u256, member: ContractAddress
     ) -> bool;
+    fn is_owner_or_member_of_profile(
+        self: @TContractState, profile_id: u256, member: ContractAddress
+    ) -> bool;
 }
 #[starknet::contract]
 pub mod Registry {
@@ -197,6 +200,13 @@ pub mod Registry {
         // Use u256 instead of bytes32
         // Down below is the function that is to be implemented in the contract but in cairo.
         // https://github.com/allo-protocol/allo-v2/blob/4dd0ea34a504a16ac90e80f49a5570b8be9b30e9/contracts/core/Registry.sol#L229
+
+        fn is_owner_or_member_of_profile(
+            self: @ContractState, profile_id: u256, member: ContractAddress
+        ) -> bool {
+            return self._is_owner_of_profile(profile_id, member)
+                || self._is_member_of_profile(profile_id, member);
+        }
 
         // Issue no. #3 Implement the functionality of isOwnerOfProfile
         // Down below is the function that is to be implemented in the contract but in cairo.


### PR DESCRIPTION
# feat: is_member_of_profile 

Implemented is_member_of_profile function to check membership status in a profile.
Added internal helper _is_member_of_profile for membership verification.

Note that I have used felt252 as the data type for profile_id as the openzeppeline [accesscontrol.cairo ](https://github.com/OpenZeppelin/cairo-contracts/blob/1e9a40b892dbd7cbd63f2c3b7368a9f3434fbd3f/packages/access/src/accesscontrol/accesscontrol.cairo#L149C9-L153C10)&nbsp; passes felt252 as an argument.
Let me know if anything else needs to be changed. 

Fixes #5 

# feat: is_owner_or_member_of_profile

Implemented is_owner_or_member_of_profile function. 

Fixes #10 